### PR TITLE
add translate-comments feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,7 @@ Thanks for contributing! 🦋🙌
 - [](# "collapsible-content-button") [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [](# "edit-comments-faster") [Lets you edit any comment with one click instead of having to open a dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
+- [](# "translate-comments") [Lets you translate any comment into another language.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
 - [](# "comment-fields-keyboard-shortcuts") [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
 - [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif) `[` `` ` `` `'` `"` `*` `~` `_`
 - [](# "minimize-upload-bar") [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/17612510/99140148-205dd380-2693-11eb-9a61-9c228f8f9e36.png)

--- a/source/features/translate-comments.tsx
+++ b/source/features/translate-comments.tsx
@@ -4,42 +4,65 @@ import onetime from 'onetime';
 import {observe} from 'selector-observer';
 import {GlobeIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
-
 import features from '.';
 
-console.log('translate comments...')
+async function translateComment (event: delegate.Event<MouseEvent, HTMLButtonElement>) {
+	const comment = event.delegateTarget.closest<HTMLElement>('.timeline-comment')!
+	const commentBody = comment!.querySelector('.edit-comment-hide .markdown-body')
+	const text = commentBody!.outerHTML
+	const url = 'https://html-translator.herokuapp.com/translate'
 
-async function translateComment () {
-	console.log('translateComment!')
-	const url = 'https://html-translator.herokuapp.com/translate?text=hello,%20world'
-	const request = await fetch(url);
-	const response = await request.json();
-	console.log({response})
+	// Determine target languages by pulling non-English codes from navigator.languages
+	// Microsoft Translator expects language codes in 2-letter BCP47 format
+	const languageCodes = navigator.languages.map(l => l.slice(0, 2).toLowerCase())
+	const languages = languageCodes
+		.filter((code, i) => languageCodes.indexOf(code) === i)
+		.filter(code => code !== 'en')
+
+	// Hit the translation webservice
+  const request = await fetch(url, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {'Content-Type': 'application/json'},
+    redirect: 'follow',
+    body: JSON.stringify({text, languages})
+  })
+
+	const response = await request.json()
+	
+	// Inject translations into the DOM
+	if (commentBody) {
+		for (const translation of response.translations) {
+			{ /* eslint-disable-next-line react/no-danger */ }
+			commentBody.before(<td dangerouslySetInnerHTML={{__html: translation.text}} className="d-block comment-body markdown-body js-comment-body rgh-linkified-code" />)
+			commentBody.before(<hr/>)
+		}
+	}
 }
 
 function init(): void {
-	console.log('translate comments init()')
-	// Find editable comments first, then traverse to the correct position
-	observe('.js-comment.unminimized-comment .js-comment-update:not(.rgh-translate-comment)', {
+	observe('.timeline-comment', {
 		add(comment) {
-			// comment.classList.add('rgh-translate-comment');
+			// Add a globe button to the comment
+			const subComment = comment.closest('.js-comment')!
+			if (!subComment) return
+			const details = subComment.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
+			if (!details) return
 
-			comment
-				.closest('.js-comment')!
-				.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
-				.before(
-					<button
-						type="button"
-						role="menuitem"
-						className="timeline-comment-action btn-link rgh-translate-comment"
-						aria-label="Translate comment"
-					>
-						<GlobeIcon/>
-					</button>
-				);
+			details.before(
+				<button
+					type="button"
+					role="menuitem"
+					className="timeline-comment-action btn-link rgh-translate-comment"
+					aria-label="Translate comment"
+				>
+					<GlobeIcon/>
+				</button>
+			)
 		}
 	});
 
+	// Invoke translation when the globe button is clicked
 	delegate(document, '.rgh-translate-comment', 'click', translateComment);
 }
 

--- a/source/features/translate-comments.tsx
+++ b/source/features/translate-comments.tsx
@@ -1,0 +1,52 @@
+import delegate from 'delegate-it';
+import React from 'dom-chef';
+import onetime from 'onetime';
+import {observe} from 'selector-observer';
+import {GlobeIcon} from '@primer/octicons-react';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+console.log('translate comments...')
+
+async function translateComment () {
+	console.log('translateComment!')
+	const url = 'https://html-translator.herokuapp.com/translate?text=hello,%20world'
+	const request = await fetch(url);
+	const response = await request.json();
+	console.log({response})
+}
+
+function init(): void {
+	console.log('translate comments init()')
+	// Find editable comments first, then traverse to the correct position
+	observe('.js-comment.unminimized-comment .js-comment-update:not(.rgh-translate-comment)', {
+		add(comment) {
+			// comment.classList.add('rgh-translate-comment');
+
+			comment
+				.closest('.js-comment')!
+				.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
+				.before(
+					<button
+						type="button"
+						role="menuitem"
+						className="timeline-comment-action btn-link rgh-translate-comment"
+						aria-label="Translate comment"
+					>
+						<GlobeIcon/>
+					</button>
+				);
+		}
+	});
+
+	delegate(document, '.rgh-translate-comment', 'click', translateComment);
+}
+
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.hasComments
+	],
+	init: onetime(init)
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -48,6 +48,7 @@ import './features/hide-navigation-hover-highlight';
 import './features/selection-in-new-tab';
 import './features/hide-comments-faster';
 import './features/edit-comments-faster';
+import './features/translate-comments';
 import './features/open-all-notifications';
 import './features/copy-on-y';
 import './features/profile-hotkey';


### PR DESCRIPTION
This PR adds support for translating GitHub issue comments into different languages using a remote webservice, powered by the Microsoft Translator API.

## To use

Build the extension or download a [.zip build](https://github.com/zeke/refined-github/files/6112327/distribution.zip)

1. clone this repo and check out the `translate-comments` branch
1. `npm install`
1. `npm run build` (or `npm run watch` if you plan to edit the extension)

Load the extension:

1. Open `chrome://extensions`
1. Click "Load unpacked".
1. In the file dialog, navigate to `your/refined-github/distribution`

Use the extension:

1. Open `chrome://settings/languages` and add one or more languages beyond English
1. Visit any GitHub issue page. You should see a 🌐 in each comment's header:

<img width="160" alt="Screen Shot 2021-03-09 at 4 43 23 PM" src="https://user-images.githubusercontent.com/2289/110558953-36871800-80f8-11eb-8c92-e7fd2603a609.png">


cc @bigzoo @mjacobus @southgate